### PR TITLE
BUG: Remove  height setting in app component

### DIFF
--- a/angular-web-site/src/app/app.component.html
+++ b/angular-web-site/src/app/app.component.html
@@ -1,7 +1,7 @@
 <app-header></app-header>
 <div class="container" >
   <div class="row">
-    <div class="col-md-12" style="height: 74vh;">
+    <div class="col-md-12">
       <router-outlet></router-outlet>
       </div>
   </div>


### PR DESCRIPTION
I had specified a height setting in the app component which is unnecessary and causes the footer to appear in the middle of the project details.
Removing it solved the problem  